### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://pablosoundaudio.visualstudio.com/cbf3b96f-c6fd-492f-9016-02fe559de373/e8401682-e855-4704-b68c-ed612f88063d/_apis/work/boardbadge/6aca353a-0899-4e2d-b228-373bd0328b16)](https://pablosoundaudio.visualstudio.com/cbf3b96f-c6fd-492f-9016-02fe559de373/_boards/board/t/e8401682-e855-4704-b68c-ed612f88063d/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://pablosoundaudio.visualstudio.com/cbf3b96f-c6fd-492f-9016-02fe559de373/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pablosound/PABLOSOUNDAUDIO/5)
<!-- Reviewable:end -->
